### PR TITLE
Fix import to ZSink

### DIFF
--- a/src/main/scala/zio/interop/reactiveStreams/SubscriberHelpers.scala
+++ b/src/main/scala/zio/interop/reactiveStreams/SubscriberHelpers.scala
@@ -1,7 +1,7 @@
 package zio.interop.reactiveStreams
 
 import org.reactivestreams.{ Subscriber, Subscription }
-import zio.stream.Sink.Step
+import zio.stream.ZSink.Step
 import zio.stream.ZSink
 import zio.{ Chunk, Queue, Runtime, UIO }
 


### PR DESCRIPTION
This will hopefully help to fix failing docs compilation
in this PR: https://github.com/zio/zio/pull/1144

Since Sink val (which refer to `ZSink`) in package object will now be replaced by a real
companinon object it will loose some ZSink methods. It seems that the
intention here was to import ZSink