### PR TITLE
Rename package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library provides an interoperability layer for reactive streams.
 ## Reactive Streams `Producer` and `Subscriber`
 
 **ZIO** integrates with [Reactive Streams](http://reactivestreams.org) by providing conversions from `zio.stream.Stream` to `org.reactivestreams.Publisher`
-and from `zio.stream.Sink` to `org.reactivestreams.Subscriber` and vice versa. Simply import `import zio.interop.reactiveStreams._` to make the 
+and from `zio.stream.Sink` to `org.reactivestreams.Subscriber` and vice versa. Simply import `import zio.interop.reactivestreams._` to make the
 conversions available.
 
 ## Examples
@@ -19,7 +19,7 @@ First, let's get a few imports out of the way.
 ```scala mdoc:silent
 import org.reactivestreams.example.unicast._
 import zio._
-import zio.interop.reactiveStreams._
+import zio.interop.reactivestreams._
 import zio.stream._
 
 val runtime = new DefaultRuntime {}

--- a/build.sbt
+++ b/build.sbt
@@ -35,10 +35,10 @@ addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
 
-lazy val reactiveStreams = project
+lazy val interopReactiveStreams = project
   .in(file("."))
   .enablePlugins(BuildInfoPlugin)
-  .settings(stdSettings("zio-interop-reactiveStreams"))
+  .settings(stdSettings("zio-interop-reactivestreams"))
   .settings(buildInfoSettings)
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
   .settings(

--- a/src/main/scala/zio/interop/reactivestreams/Adapters.scala
+++ b/src/main/scala/zio/interop/reactivestreams/Adapters.scala
@@ -1,4 +1,4 @@
-package zio.interop.reactiveStreams
+package zio.interop.reactivestreams
 
 import org.reactivestreams.{ Publisher, Subscriber, Subscription }
 import zio._

--- a/src/main/scala/zio/interop/reactivestreams/package.scala
+++ b/src/main/scala/zio/interop/reactivestreams/package.scala
@@ -4,7 +4,7 @@ import org.reactivestreams.{ Publisher, Subscriber }
 import zio.stream.{ ZSink, ZStream }
 import zio.{ IO, Promise, UIO, ZIO, ZManaged }
 
-package object reactiveStreams {
+package object reactivestreams {
 
   final implicit class streamToPublisher[R, E <: Throwable, A](private val stream: ZStream[R, E, A]) extends AnyVal {
 

--- a/src/test/scala/scalaz/zio/interop/reactiveStreams/PublisherToStreamSpec.scala
+++ b/src/test/scala/scalaz/zio/interop/reactiveStreams/PublisherToStreamSpec.scala
@@ -1,9 +1,9 @@
-package zio.interop.reactiveStreams
+package zio.interop.reactivestreams
 
 import org.reactivestreams.tck.TestEnvironment
 import org.reactivestreams.tck.TestEnvironment.ManualPublisher
 import zio.{ Exit, Task, UIO }
-import zio.interop.reactiveStreams.PublisherToStreamSpecUtil._
+import zio.interop.reactivestreams.PublisherToStreamSpecUtil._
 import zio.stream.Sink
 import zio.test._
 import zio.test.Assertion._

--- a/src/test/scala/scalaz/zio/interop/reactiveStreams/SinkToSubscriberSpec.scala
+++ b/src/test/scala/scalaz/zio/interop/reactiveStreams/SinkToSubscriberSpec.scala
@@ -1,4 +1,4 @@
-package zio.interop.reactiveStreams
+package zio.interop.reactivestreams
 
 import org.reactivestreams.{ Publisher, Subscriber, Subscription }
 import org.reactivestreams.tck.{ SubscriberWhiteboxVerification, TestEnvironment }

--- a/src/test/scala/scalaz/zio/interop/reactiveStreams/StreamToPublisherSpec.scala
+++ b/src/test/scala/scalaz/zio/interop/reactiveStreams/StreamToPublisherSpec.scala
@@ -1,4 +1,4 @@
-package zio.interop.reactiveStreams
+package zio.interop.reactivestreams
 
 import java.lang.reflect.InvocationTargetException
 import org.reactivestreams.Publisher

--- a/src/test/scala/scalaz/zio/interop/reactiveStreams/SubscriberToSinkSpec.scala
+++ b/src/test/scala/scalaz/zio/interop/reactiveStreams/SubscriberToSinkSpec.scala
@@ -1,11 +1,11 @@
-package zio.interop.reactiveStreams
+package zio.interop.reactivestreams
 
 import org.reactivestreams.tck.TestEnvironment
 import org.reactivestreams.tck.TestEnvironment.ManualSubscriberWithSubscriptionSupport
 import scala.jdk.CollectionConverters._
 import zio.{ Task, UIO, ZIO }
 import zio.blocking._
-import zio.interop.reactiveStreams.SubscriberToSinkSpecUtil._
+import zio.interop.reactivestreams.SubscriberToSinkSpecUtil._
 import zio.stream.Stream
 import zio.test._
 import zio.test.Assertion._


### PR DESCRIPTION
Rename package so that name mirrors `org.reactivestreams` style. By the way, `all-lowercase` is a preferred way to name packages: https://www.oracle.com/technetwork/java/codeconventions-135099.html

One more reference example:
https://github.com/mongodb/mongo-java-driver-reactivestreams/tree/master/driver/src/main/com/mongodb/reactivestreams