### PR TITLE
Zio RC18

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "2.3.2"
+version = "2.4.2"
 maxColumn = 120
 align = most
 continuationIndent.defnSite = 2

--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,10 @@ addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
 
+val zioVersion        = "1.0.0-RC17+437-68ccb44d-SNAPSHOT"
+val rsVersion         = "1.0.3"
+val collCompatVersion = "2.1.4"
+
 lazy val interopReactiveStreams = project
   .in(file("."))
   .enablePlugins(BuildInfoPlugin)
@@ -42,13 +46,14 @@ lazy val interopReactiveStreams = project
   .settings(buildInfoSettings)
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
   .settings(
+    resolvers += Resolver.sonatypeRepo("snapshots"),
     libraryDependencies ++= Seq(
-      "dev.zio"                %% "zio"                     % "1.0.0-RC17",
-      "dev.zio"                %% "zio-streams"             % "1.0.0-RC17",
-      "dev.zio"                %% "zio-test"                % "1.0.0-RC17" % Test,
-      "dev.zio"                %% "zio-test-sbt"            % "1.0.0-RC17" % Test,
-      "org.reactivestreams"    % "reactive-streams"         % "1.0.3",
-      "org.reactivestreams"    % "reactive-streams-tck"     % "1.0.3" % Test,
-      "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.4" % Test
+      "dev.zio"                %% "zio"                     % zioVersion,
+      "dev.zio"                %% "zio-streams"             % zioVersion,
+      "dev.zio"                %% "zio-test"                % zioVersion % Test,
+      "dev.zio"                %% "zio-test-sbt"            % zioVersion % Test,
+      "org.reactivestreams"    % "reactive-streams"         % rsVersion,
+      "org.reactivestreams"    % "reactive-streams-tck"     % rsVersion % Test,
+      "org.scala-lang.modules" %% "scala-collection-compat" % collCompatVersion % Test
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
 
-val zioVersion        = "1.0.0-RC17+437-68ccb44d-SNAPSHOT"
+val zioVersion        = "1.0.0-RC18-1"
 val rsVersion         = "1.0.3"
 val collCompatVersion = "2.1.4"
 

--- a/src/main/scala/zio/interop/reactivestreams/Adapters.scala
+++ b/src/main/scala/zio/interop/reactivestreams/Adapters.scala
@@ -56,7 +56,6 @@ object Adapters {
   ): ZIO[R1, Throwable, (Subscriber[A], IO[Throwable, B])] =
     for {
       (q, subscription, completion, subscriber) <- makeSubscriber[A](bufferSize)
-      result                                    <- Promise.make[Throwable, B]
       pull = subscription.await.toManaged_
         .onExitFirst(_.foreach(sub => UIO(sub.cancel()).whenM(completion.isDone.map(!_))))
         .flatMap(process(q, _, completion))

--- a/src/main/scala/zio/interop/reactivestreams/Adapters.scala
+++ b/src/main/scala/zio/interop/reactivestreams/Adapters.scala
@@ -19,7 +19,7 @@ object Adapters {
             _ <- stream
                   .run(demandUnfoldSink(subscriber, demand))
                   .catchAll(e => UIO(subscriber.onError(e)))
-                  .fork
+                  .forkDaemon
           } yield ()
         )
       }
@@ -34,7 +34,7 @@ object Adapters {
       error        <- Promise.make[E, Nothing]
       subscription = createSubscription(subscriber, demand, runtime)
       _            <- UIO(subscriber.onSubscribe(subscription))
-      _            <- error.await.catchAll(t => UIO(subscriber.onError(t)) *> demand.shutdown).fork
+      _            <- error.await.catchAll(t => UIO(subscriber.onError(t)) *> demand.shutdown).forkDaemon
     } yield (error, demandUnfoldSink(subscriber, demand))
 
   def publisherToStream[A](publisher: Publisher[A], bufferSize: Int): ZStream[Any, Throwable, A] = {

--- a/src/main/scala/zio/interop/reactivestreams/package.scala
+++ b/src/main/scala/zio/interop/reactivestreams/package.scala
@@ -2,7 +2,7 @@ package zio.interop
 
 import org.reactivestreams.{ Publisher, Subscriber }
 import zio.stream.{ ZSink, ZStream }
-import zio.{ IO, Promise, UIO, ZIO, ZManaged }
+import zio.{ IO, Promise, UIO, ZIO }
 
 package object reactivestreams {
 
@@ -26,7 +26,7 @@ package object reactivestreams {
      * @param qSize The size used as internal buffer. If possible, set to a power of 2 value for best performance.
      *
      */
-    def toSubscriber[R1 <: R](qSize: Int = 16): ZManaged[R1, Throwable, (Subscriber[A], IO[Throwable, B])] =
+    def toSubscriber[R1 <: R](qSize: Int = 16): ZIO[R1, Throwable, (Subscriber[A], IO[Throwable, B])] =
       Adapters.sinkToSubscriber(sink, qSize)
   }
 

--- a/src/test/scala/scalaz/zio/interop/reactiveStreams/PublisherToStreamSpec.scala
+++ b/src/test/scala/scalaz/zio/interop/reactiveStreams/PublisherToStreamSpec.scala
@@ -3,60 +3,55 @@ package zio.interop.reactivestreams
 import org.reactivestreams.tck.TestEnvironment
 import org.reactivestreams.tck.TestEnvironment.ManualPublisher
 import zio.{ Exit, Task, UIO }
-import zio.interop.reactivestreams.PublisherToStreamSpecUtil._
 import zio.stream.Sink
 import zio.test._
 import zio.test.Assertion._
 
-object PublisherToStreamSpec
-    extends DefaultRunnableSpec(
-      suite("Converting a `Publisher` to a `Stream`")(
-        testM("works with a well behaved `Publisher`") {
-          assertM(publish(seq, None), succeeds(equalTo(seq)))
-        },
-        testM("fails with an initially failed `Publisher`") {
-          assertM(publish(Nil, Some(e)), fails(equalTo(e)))
-        },
-        testM("fails with an eventually failing `Publisher`") {
-          assertM(publish(seq, Some(e)), fails(equalTo(e)))
-        },
-        testM("cancels subscription when interrupted before subscription") {
-          for {
-            probe <- makeProbe
-            fiber <- probe.toStream(bufferSize).run(Sink.drain).fork
-            _     <- fiber.interrupt
-            r     <- Task(probe.expectCancelling()).run
-          } yield assert(r, succeeds(isUnit))
-        },
-        testM("cancels subscription when interrupted after subscription") {
-          assertM(
-            (for {
-              probe <- makeProbe
-              fiber <- probe.toStream(bufferSize).run(Sink.drain).fork
-              _     <- Task(probe.expectRequest())
-              _     <- fiber.interrupt
-              _     <- Task(probe.expectCancelling())
-            } yield ()).run,
-            succeeds(isUnit)
-          )
-        },
-        testM("cancels subscription when interrupted during consumption") {
-          assertM(
-            (for {
-              probe  <- makeProbe
-              fiber  <- probe.toStream(bufferSize).run(Sink.drain).fork
-              demand <- Task(probe.expectRequest())
-              _      <- Task((1 to demand.toInt).foreach(i => probe.sendNext(i)))
-              _      <- fiber.interrupt
-              _      <- Task(probe.expectCancelling())
-            } yield ()).run,
-            succeeds(isUnit)
-          )
-        }
-      )
-    )
+object PublisherToStreamSpec extends DefaultRunnableSpec {
 
-object PublisherToStreamSpecUtil {
+  override def spec =
+    suite("Converting a `Publisher` to a `Stream`")(
+      testM("works with a well behaved `Publisher`") {
+        assertM(publish(seq, None))(succeeds(equalTo(seq)))
+      },
+      testM("fails with an initially failed `Publisher`") {
+        assertM(publish(Nil, Some(e)))(fails(equalTo(e)))
+      },
+      testM("fails with an eventually failing `Publisher`") {
+        assertM(publish(seq, Some(e)))(fails(equalTo(e)))
+      },
+      testM("cancels subscription when interrupted before subscription") {
+        for {
+          probe <- makeProbe
+          fiber <- probe.toStream(bufferSize).run(Sink.drain).fork
+          _     <- fiber.interrupt
+          r     <- Task(probe.expectCancelling()).run
+        } yield assert(r)(succeeds(isUnit))
+      },
+      testM("cancels subscription when interrupted after subscription") {
+        assertM((for {
+          probe <- makeProbe
+          fiber <- probe.toStream(bufferSize).run(Sink.drain).fork
+          _     <- Task(probe.expectRequest())
+          _     <- fiber.interrupt
+          _     <- Task(probe.expectCancelling())
+        } yield ()).run)(
+          succeeds(isUnit)
+        )
+      },
+      testM("cancels subscription when interrupted during consumption") {
+        assertM((for {
+          probe  <- makeProbe
+          fiber  <- probe.toStream(bufferSize).run(Sink.drain).fork
+          demand <- Task(probe.expectRequest())
+          _      <- Task((1 to demand.toInt).foreach(i => probe.sendNext(i)))
+          _      <- fiber.interrupt
+          _      <- Task(probe.expectCancelling())
+        } yield ()).run)(
+          succeeds(isUnit)
+        )
+      }
+    )
 
   val e: Throwable    = new RuntimeException("boom")
   val seq: List[Int]  = List.range(0, 100)
@@ -70,7 +65,7 @@ object PublisherToStreamSpecUtil {
     def loop(probe: ManualPublisher[Int], remaining: List[Int], pending: Int): Task[Unit] =
       for {
         n             <- Task(probe.expectRequest())
-        _             <- Task(assert(n.toInt + pending, isLessThanEqualTo(bufferSize)))
+        _             <- Task(assert(n.toInt + pending)(isLessThanEqualTo(bufferSize)))
         half          = n.toInt / 2 + 1
         (nextN, tail) = remaining.splitAt(half)
         _             <- Task(nextN.foreach(probe.sendNext))

--- a/src/test/scala/scalaz/zio/interop/reactiveStreams/SinkToSubscriberSpec.scala
+++ b/src/test/scala/scalaz/zio/interop/reactiveStreams/SinkToSubscriberSpec.scala
@@ -12,76 +12,73 @@ import zio.test._
 import zio.test.Assertion._
 import zio.{ Promise, Task, UIO, ZIO, ZManaged }
 
-object SinkToSubscriberSpec
-    extends DefaultRunnableSpec(
-      suite("Converting a `Sink` to a `Subscriber`")(
-        testM("works on the happy path")(
-          for {
-            (publisher, subscribed, requested, canceled) <- SinkToSubscriberTestUtil.makePublisherProbe
-            fiber <- Sink
-                      .collectAllN[Int](5)
-                      .toSubscriber()
-                      .use {
-                        case (subscriber, r) => UIO(publisher.subscribe(subscriber)) *> r
-                      }
-                      .fork
-            _ <- assertM(subscribed.await.timeoutFail("timeout awaiting subscribe.")(500.millis).run, succeeds(isUnit))
-            _ <- assertM(requested.await.timeoutFail("timeout awaiting request.")(500.millis).run, succeeds(isUnit))
-            _ <- assertM(canceled.await.timeoutFail("timeout awaiting cancel.")(500.millis).run, succeeds(isUnit))
-            r <- fiber.join.run
-          } yield assert(r, succeeds(equalTo(List(1, 2, 3, 4, 5))))
-        ),
-        testM("cancels subscription on interruption after subscription")(
-          for {
-            (publisher, subscribed, _, canceled) <- SinkToSubscriberTestUtil.makePublisherProbe
-            fiber <- Sink.drain
-                      .toSubscriber()
-                      .use { case (subscriber, _) => UIO(publisher.subscribe(subscriber)) *> UIO.never }
-                      .fork
-            _ <- assertM(subscribed.await.timeoutFail("timeout awaiting subscribe.")(500.millis).run, succeeds(isUnit))
-            _ <- fiber.interrupt
-            _ <- assertM(canceled.await.timeoutFail("timeout awaiting cancel.")(500.millis).run, succeeds(isUnit))
-            r <- fiber.join.run
-          } yield assert(r, isInterrupted)
-        ),
-        testM("cancels subscription on interruption during consuption")(
-          for {
-            (publisher, subscribed, requested, canceled) <- SinkToSubscriberTestUtil.makePublisherProbe
-            fiber <- Sink.drain
-                      .toSubscriber()
-                      .use { case (subscriber, _) => UIO(publisher.subscribe(subscriber)) *> UIO.never }
-                      .fork
-            _ <- assertM(subscribed.await.timeoutFail("timeout awaiting subscribe.")(500.millis).run, succeeds(isUnit))
-            _ <- assertM(requested.await.timeoutFail("timeout awaiting request.")(500.millis).run, succeeds(isUnit))
-            _ <- fiber.interrupt
-            _ <- assertM(canceled.await.timeoutFail("timeout awaiting cancel.")(500.millis).run, succeeds(isUnit))
-            r <- fiber.join.run
-          } yield assert(r, isInterrupted)
-        ),
-        testM("Does not fail a fiber on failing Publisher") {
-          val publisher = new Publisher[Int] {
-            override def subscribe(s: Subscriber[_ >: Int]): Unit =
-              s.onSubscribe(
-                new Subscription {
-                  override def request(n: Long): Unit = s.onError(new Throwable("boom!"))
-                  override def cancel(): Unit         = ()
-                }
-              )
-          }
-          ZIO.runtime[Any].map { runtime =>
-            var fibersFailed = 0
-            val testRuntime  = runtime.mapPlatform(_.withReportFailure(_ => fibersFailed += 1))
-            val exit         = testRuntime.unsafeRun(publisher.toStream().runDrain.run)
-            assert(exit, fails(anything)) && assert(fibersFailed, equalTo(0))
-          }
-        },
-        suite("passes all required and optional TCK tests")(
-          SinkToSubscriberTestUtil.tests: _*
-        )
+object SinkToSubscriberSpec extends DefaultRunnableSpec {
+  override def spec =
+    suite("Converting a `Sink` to a `Subscriber`")(
+      testM("works on the happy path")(
+        for {
+          (publisher, subscribed, requested, canceled) <- makePublisherProbe
+          fiber <- Sink
+                    .collectAllN[Int](5)
+                    .toSubscriber()
+                    .use {
+                      case (subscriber, r) => UIO(publisher.subscribe(subscriber)) *> r
+                    }
+                    .fork
+          _ <- assertM(subscribed.await.timeoutFail("timeout awaiting subscribe.")(500.millis).run)(succeeds(isUnit))
+          _ <- assertM(requested.await.timeoutFail("timeout awaiting request.")(500.millis).run)(succeeds(isUnit))
+          _ <- assertM(canceled.await.timeoutFail("timeout awaiting cancel.")(500.millis).run)(succeeds(isUnit))
+          r <- fiber.join.run
+        } yield assert(r)(succeeds(equalTo(List(1, 2, 3, 4, 5))))
+      ),
+      testM("cancels subscription on interruption after subscription")(
+        for {
+          (publisher, subscribed, _, canceled) <- makePublisherProbe
+          fiber <- Sink.drain
+                    .toSubscriber()
+                    .use { case (subscriber, _) => UIO(publisher.subscribe(subscriber)) *> UIO.never }
+                    .fork
+          _ <- assertM(subscribed.await.timeoutFail("timeout awaiting subscribe.")(500.millis).run)(succeeds(isUnit))
+          _ <- fiber.interrupt
+          _ <- assertM(canceled.await.timeoutFail("timeout awaiting cancel.")(500.millis).run)(succeeds(isUnit))
+          r <- fiber.join.run
+        } yield assert(r)(isInterrupted)
+      ),
+      testM("cancels subscription on interruption during consuption")(
+        for {
+          (publisher, subscribed, requested, canceled) <- makePublisherProbe
+          fiber <- Sink.drain
+                    .toSubscriber()
+                    .use { case (subscriber, _) => UIO(publisher.subscribe(subscriber)) *> UIO.never }
+                    .fork
+          _ <- assertM(subscribed.await.timeoutFail("timeout awaiting subscribe.")(500.millis).run)(succeeds(isUnit))
+          _ <- assertM(requested.await.timeoutFail("timeout awaiting request.")(500.millis).run)(succeeds(isUnit))
+          _ <- fiber.interrupt
+          _ <- assertM(canceled.await.timeoutFail("timeout awaiting cancel.")(500.millis).run)(succeeds(isUnit))
+          r <- fiber.join.run
+        } yield assert(r)(isInterrupted)
+      ),
+      testM("Does not fail a fiber on failing Publisher") {
+        val publisher = new Publisher[Int] {
+          override def subscribe(s: Subscriber[_ >: Int]): Unit =
+            s.onSubscribe(
+              new Subscription {
+                override def request(n: Long): Unit = s.onError(new Throwable("boom!"))
+                override def cancel(): Unit         = ()
+              }
+            )
+        }
+        ZIO.runtime[Any].map { runtime =>
+          var fibersFailed = 0
+          val testRuntime  = runtime.mapPlatform(_.withReportFailure(_ => fibersFailed += 1))
+          val exit         = testRuntime.unsafeRun(publisher.toStream().runDrain.run)
+          assert(exit)(fails(anything)) && assert(fibersFailed)(equalTo(0))
+        }
+      },
+      suite("passes all required and optional TCK tests")(
+        tests: _*
       )
     )
-
-object SinkToSubscriberTestUtil {
 
   val makePublisherProbe =
     for {
@@ -134,20 +131,19 @@ object SinkToSubscriberTestUtil {
   val managedVerification =
     for {
       (subscriber, _) <- Sink.collectAll[Int].toSubscriber[Clock]()
-      sbv <- ZManaged
-              .make[Clock, Throwable, (SubscriberWhiteboxVerification[Int], TestEnvironment)] {
-                val env = new TestEnvironment(1000, 500)
-                val sbv =
-                  new SubscriberWhiteboxVerification[Int](env) {
-                    override def createSubscriber(probe: WhiteboxSubscriberProbe[Int]): Subscriber[Int] =
-                      ProbedSubscriber(subscriber, probe)
-                    override def createElement(element: Int): Int = element
-                  }
-                UIO(sbv.setUp()) *> UIO(sbv.startPublisherExecutorService()).as((sbv, env))
-              } {
-                case (sbv, _) =>
-                  UIO(sbv.shutdownPublisherExecutorService())
-              }
+      sbv <- ZManaged.make {
+              val env = new TestEnvironment(1000, 500)
+              val sbv =
+                new SubscriberWhiteboxVerification[Int](env) {
+                  override def createSubscriber(probe: WhiteboxSubscriberProbe[Int]): Subscriber[Int] =
+                    ProbedSubscriber(subscriber, probe)
+                  override def createElement(element: Int): Int = element
+                }
+              UIO(sbv.setUp()) *> UIO(sbv.startPublisherExecutorService()).as((sbv, env))
+            } {
+              case (sbv, _) =>
+                UIO(sbv.shutdownPublisherExecutorService())
+            }
     } yield sbv
 
   val tests =
@@ -161,7 +157,7 @@ object SinkToSubscriberTestUtil {
       }
       .collect {
         case method if method.getName().startsWith("untested") =>
-          test(method.getName())(assert((), anything)) @@ TestAspect.ignore
+          test(method.getName())(assert(())(anything)) @@ TestAspect.ignore
         case method =>
           testM(method.getName())(
             for {
@@ -169,7 +165,7 @@ object SinkToSubscriberTestUtil {
                     case (sbv, env) =>
                       blocking(Task(method.invoke(sbv))).timeout(env.defaultTimeoutMillis().millis)
                   }.unit.run
-            } yield assert(r, succeeds(isUnit))
+            } yield assert(r)(succeeds(isUnit))
           )
       }
 

--- a/src/test/scala/scalaz/zio/interop/reactiveStreams/StreamToPublisherSpec.scala
+++ b/src/test/scala/scalaz/zio/interop/reactiveStreams/StreamToPublisherSpec.scala
@@ -12,14 +12,11 @@ import zio.stream.Stream
 import zio.test._
 import zio.test.Assertion._
 
-object StreamToPublisherSpec
-    extends DefaultRunnableSpec(
-      suite("Converting a `Stream` to a `Publisher`")(
-        suite("passes all required and optional TCK tests")(StreamToPublisherTestUtil.tests: _*)
-      )
+object StreamToPublisherSpec extends DefaultRunnableSpec {
+  override def spec =
+    suite("Converting a `Stream` to a `Publisher`")(
+      suite("passes all required and optional TCK tests")(tests: _*)
     )
-
-object StreamToPublisherTestUtil {
 
   def makePV(runtime: zio.Runtime[Any]) =
     new PublisherVerification[Int](new TestEnvironment(2000, 500), 2000L) {
@@ -51,7 +48,7 @@ object StreamToPublisherTestUtil {
       }
       .collect {
         case method if method.getName().startsWith("untested") =>
-          test(method.getName())(assert((), anything)) @@ TestAspect.ignore
+          test(method.getName())(assert(())(anything)) @@ TestAspect.ignore
         case method =>
           testM(method.getName())(
             for {
@@ -61,7 +58,7 @@ object StreamToPublisherTestUtil {
               r <- blocking(Task(method.invoke(pv))).unit.mapError {
                     case e: InvocationTargetException => e.getTargetException()
                   }.run
-            } yield assert(r, succeeds(isUnit))
+            } yield assert(r)(succeeds(isUnit))
           )
       }
 }

--- a/src/test/scala/scalaz/zio/interop/reactiveStreams/SubscriberToSinkSpec.scala
+++ b/src/test/scala/scalaz/zio/interop/reactiveStreams/SubscriberToSinkSpec.scala
@@ -5,45 +5,41 @@ import org.reactivestreams.tck.TestEnvironment.ManualSubscriberWithSubscriptionS
 import scala.jdk.CollectionConverters._
 import zio.{ Task, UIO, ZIO }
 import zio.blocking._
-import zio.interop.reactivestreams.SubscriberToSinkSpecUtil._
 import zio.stream.Stream
 import zio.test._
 import zio.test.Assertion._
 
-object SubscriberToSinkSpec
-    extends DefaultRunnableSpec(
-      suite("Converting a `Subscriber` to a `Sink`")(
-        testM("works on the happy path") {
-          for {
-            probe         <- makeSubscriber
-            errorSink     <- probe.underlying.toSink[Throwable]
-            (error, sink) = errorSink
-            fiber         <- Stream.fromIterable(seq).run(sink).catchAll(t => error.fail(t)).fork
-            _             <- probe.request(length + 1)
-            elements      <- probe.nextElements(length).run
-            completion    <- probe.expectCompletion.run
-            _             <- fiber.join
-          } yield assert(elements, succeeds(equalTo(seq))) && assert(completion, succeeds(isUnit))
-        },
-        testM("transports errors") {
-          for {
-            probe         <- makeSubscriber
-            errorSink     <- probe.underlying.toSink[Throwable]
-            (error, sink) = errorSink
-            fiber <- (Stream.fromIterable(seq) ++
-                      //         Stream.fromIterable(seq) ++
-                      Stream.fail(e)).run(sink).catchAll(t => error.fail(t)).fork
-            _        <- probe.request(length + 1)
-            elements <- probe.nextElements(length).run
-            err      <- probe.expectError.run
-            _        <- fiber.join
-          } yield assert(elements, succeeds(equalTo(seq))) && assert(err, succeeds(equalTo(e)))
-        }
-      )
+object SubscriberToSinkSpec extends DefaultRunnableSpec {
+  override def spec =
+    suite("Converting a `Subscriber` to a `Sink`")(
+      testM("works on the happy path") {
+        for {
+          probe         <- makeSubscriber
+          errorSink     <- probe.underlying.toSink[Throwable]
+          (error, sink) = errorSink
+          fiber         <- Stream.fromIterable(seq).run(sink).catchAll(t => error.fail(t)).fork
+          _             <- probe.request(length + 1)
+          elements      <- probe.nextElements(length).run
+          completion    <- probe.expectCompletion.run
+          _             <- fiber.join
+        } yield assert(elements)(succeeds(equalTo(seq))) && assert(completion)(succeeds(isUnit))
+      },
+      testM("transports errors") {
+        for {
+          probe         <- makeSubscriber
+          errorSink     <- probe.underlying.toSink[Throwable]
+          (error, sink) = errorSink
+          fiber <- (Stream.fromIterable(seq) ++
+                    //         Stream.fromIterable(seq) ++
+                    Stream.fail(e)).run(sink).catchAll(t => error.fail(t)).fork
+          _        <- probe.request(length + 1)
+          elements <- probe.nextElements(length).run
+          err      <- probe.expectError.run
+          _        <- fiber.join
+        } yield assert(elements)(succeeds(equalTo(seq))) && assert(err)(succeeds(equalTo(e)))
+      }
     )
 
-object SubscriberToSinkSpecUtil {
-  // ManualSubscriberWithSubscriptionSupport has an internal buffer of at most 32 elements.
   val seq: List[Int] = List.range(0, 31)
   val length: Long   = seq.length.toLong
   val e: Throwable   = new RuntimeException("boom")
@@ -60,4 +56,5 @@ object SubscriberToSinkSpecUtil {
   }
 
   val makeSubscriber = UIO(new ManualSubscriberWithSubscriptionSupport[Int](new TestEnvironment(2000))).map(Probe.apply)
+
 }


### PR DESCRIPTION
* bump ZIO to RC18
* migrate to new Stream encoding
* fork cleanup fibers as daemon
* simplify sinkToSubscriber API to return ZIO
* migrate tests