### PR TITLE
BuildInfo object collides with BuildInfo from ZIO

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -31,7 +31,7 @@ object BuildHelper {
   val buildInfoSettings = Seq(
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, isSnapshot),
     buildInfoPackage := "zio",
-    buildInfoObject := "BuildInfo"
+    buildInfoObject := "BuildInfoInteropReactiveStreams"
   )
 
   def extraOptions(scalaVersion: String) =


### PR DESCRIPTION
rename BuildInfo to BuildInfoInteropReactiveStreams, because this causes problems for example when generating assemblies:

```
[error] deduplicate: different file contents found in the following:
[error] /Users/user0/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/dev/zio/zio-interop-reactivestreams_2.13/1.0.3.5-RC6/zio-interop-reactivestreams_2.13-1.0.3.5-RC6.jar:zio/BuildInfo$.class
[error] /Users/user0/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/dev/zio/zio_2.13/1.0.0-RC18-2/zio_2.13-1.0.0-RC18-2.jar:zio/BuildInfo$.class

```
