### PR TITLE
fix cancellation for publisherToStream

### DIFF
--- a/src/test/scala/zio/interop/reactivestreams/PublisherToStreamSpec.scala
+++ b/src/test/scala/zio/interop/reactivestreams/PublisherToStreamSpec.scala
@@ -1,17 +1,13 @@
 package zio.interop.reactivestreams
 
-import org.reactivestreams.Publisher
-import org.reactivestreams.Subscriber
-import org.reactivestreams.Subscription
+import org.reactivestreams.{ Publisher, Subscriber, Subscription }
 import org.reactivestreams.tck.TestEnvironment
 import org.reactivestreams.tck.TestEnvironment.ManualPublisher
-import zio.{ Exit, Task, UIO, ZIO }
+import zio.{ Exit, Promise, Task, UIO, ZIO }
 import zio.duration._
-import zio.stream.Sink
-import zio.stream.Stream
+import zio.stream.{ Sink, Stream }
 import zio.test._
 import zio.test.Assertion._
-import zio.Promise
 
 object PublisherToStreamSpec extends DefaultRunnableSpec {
 

--- a/src/test/scala/zio/interop/reactivestreams/PublisherToStreamSpec.scala
+++ b/src/test/scala/zio/interop/reactivestreams/PublisherToStreamSpec.scala
@@ -130,7 +130,7 @@ object PublisherToStreamSpec extends DefaultRunnableSpec {
   def withProbe[R, E0, E >: Throwable, A](f: ManualPublisher[Int] => ZIO[R, E, A]): ZIO[R, E, A] = {
     val testEnv = new TestEnvironment(3000, 500)
     val probe   = new ManualPublisher[Int](testEnv)
-    f(probe) <* Task(testEnv.verifyNoAsyncErrorsNoDelay()).mapError { t => t.setStackTrace(Array.empty); t }
+    f(probe) <* Task(testEnv.verifyNoAsyncErrorsNoDelay())
   }
 
   def publish(seq: List[Int], failure: Option[Throwable]): UIO[Exit[Throwable, List[Int]]] = {

--- a/src/test/scala/zio/interop/reactivestreams/PublisherToStreamSpec.scala
+++ b/src/test/scala/zio/interop/reactivestreams/PublisherToStreamSpec.scala
@@ -98,6 +98,7 @@ object PublisherToStreamSpec extends DefaultRunnableSpec {
           demand <- Task(probe.expectRequest())
           _      <- Task((1 to demand.toInt).foreach(i => probe.sendNext(i)))
           _      <- Task(probe.expectCancelling())
+          _      <- fiber.join
         } yield ()).run)(
           succeeds(isUnit)
         )
@@ -109,8 +110,9 @@ object PublisherToStreamSpec extends DefaultRunnableSpec {
           demand <- Task(probe.expectRequest())
           _      <- Task((1 to demand.toInt).foreach(i => probe.sendNext(i)))
           _      <- Task(probe.expectCancelling())
+          _      <- fiber.join
         } yield ()).run)(
-          succeeds(isUnit)
+          fails(anything)
         )
       }
     )

--- a/src/test/scala/zio/interop/reactivestreams/PublisherToStreamSpec.scala
+++ b/src/test/scala/zio/interop/reactivestreams/PublisherToStreamSpec.scala
@@ -128,7 +128,7 @@ object PublisherToStreamSpec extends DefaultRunnableSpec {
   val bufferSize: Int = 10
 
   def withProbe[R, E0, E >: Throwable, A](f: ManualPublisher[Int] => ZIO[R, E, A]): ZIO[R, E, A] = {
-    val testEnv = new TestEnvironment(2000, 500)
+    val testEnv = new TestEnvironment(3000, 500)
     val probe   = new ManualPublisher[Int](testEnv)
     f(probe) <* Task(testEnv.verifyNoAsyncErrorsNoDelay()).mapError { t => t.setStackTrace(Array.empty); t }
   }

--- a/src/test/scala/zio/interop/reactivestreams/PublisherToStreamSpec.scala
+++ b/src/test/scala/zio/interop/reactivestreams/PublisherToStreamSpec.scala
@@ -128,7 +128,7 @@ object PublisherToStreamSpec extends DefaultRunnableSpec {
   val bufferSize: Int = 10
 
   def withProbe[R, E0, E >: Throwable, A](f: ManualPublisher[Int] => ZIO[R, E, A]): ZIO[R, E, A] = {
-    val testEnv = new TestEnvironment(1000)
+    val testEnv = new TestEnvironment(2000, 500)
     val probe   = new ManualPublisher[Int](testEnv)
     f(probe) <* Task(testEnv.verifyNoAsyncErrorsNoDelay()).mapError { t => t.setStackTrace(Array.empty); t }
   }


### PR DESCRIPTION
RC7 introduced a regression breaking cancellation in publisherToStream, which we missed, because our cancellation tests didn't correctly test for errors (Thanks to @Zuchos for analyzing!). This PR fixed both the tests and cancellation.