### PR TITLE
Scala 3.0.0-RC2, ZIO 1.0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ['adopt@1.8', 'adopt@1.11']
-        scala: ['2.11.12', '2.12.13', '2.13.5', '3.0.0-RC1']
+        scala: ['2.11.12', '2.12.13', '2.13.5', '3.0.0-RC2']
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v2.3.4

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 
-val zioVersion        = "1.0.5"
+val zioVersion        = "1.0.6"
 val rsVersion         = "1.0.3"
 val collCompatVersion = "2.4.3"
 

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -11,7 +11,7 @@ object BuildHelper {
   val Scala211   = "2.11.12"
   val Scala212   = "2.12.13"
   val Scala213   = "2.13.5"
-  val ScalaDotty = "3.0.0-RC1"
+  val ScalaDotty = "3.0.0-RC2"
 
   private val stdOptions = Seq(
     "-deprecation",


### PR DESCRIPTION
I'm just trying to move get Sttp to work on Scala 3.0.0-RC2, and `interop-reactive-streams` is used for the Armaria backend.
It would be great if this update could get a patch release 😃 