### PR TITLE
feat: no unsafeRun in subscriber

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,3 +63,5 @@ lazy val interopReactiveStreams = project
         Seq("org.scala-lang.modules" %% "scala-collection-compat" % collCompatVersion % Test)
     }
   )
+  .settings(Test / javaOptions += "-XX:ActiveProcessorCount=1")
+  .settings(Test / fork := true)

--- a/build.sbt
+++ b/build.sbt
@@ -63,5 +63,5 @@ lazy val interopReactiveStreams = project
         Seq("org.scala-lang.modules" %% "scala-collection-compat" % collCompatVersion % Test)
     }
   )
-  .settings(Test / javaOptions += "-XX:ActiveProcessorCount=1")
+  // .settings(Test / javaOptions += "-XX:ActiveProcessorCount=1") // uncomment to test for deadlocks
   .settings(Test / fork := true)

--- a/src/main/scala/zio/interop/reactivestreams/Adapters.scala
+++ b/src/main/scala/zio/interop/reactivestreams/Adapters.scala
@@ -47,9 +47,10 @@ object Adapters {
     } yield (error, demandUnfoldSink(sub, demand))
   }
 
-  def publisherToStream[O](publisher: => Publisher[O], bufferSize: => Int)(implicit
-    trace: ZTraceElement
-  ): ZStream[Any, Throwable, O] = {
+  def publisherToStream[O](
+    publisher: => Publisher[O],
+    bufferSize: => Int
+  )(implicit trace: ZTraceElement): ZStream[Any, Throwable, O] = {
     val pullOrFail =
       for {
         subscriberP    <- makeSubscriber[O](bufferSize)

--- a/src/test/scala/zio/interop/reactivestreams/PublisherToStreamSpec.scala
+++ b/src/test/scala/zio/interop/reactivestreams/PublisherToStreamSpec.scala
@@ -141,7 +141,7 @@ object PublisherToStreamSpec extends DefaultRunnableSpec {
           )
         )
       }
-    )
+    ) @@ TestAspect.nonFlaky
 
   val e: Throwable    = new RuntimeException("boom")
   val seq: Chunk[Int] = Chunk.fromIterable(List.range(0, 100))


### PR DESCRIPTION
Remove all `unsafeRun`s in the subscriber by replacing the ZIO Queue by a RingBuffer and using Promises and volatile vars for backpressuring. This avoids nested `unsafeRun`s in case of interacting with Java code, which can lead to blocking on single core machines. 