### PR TITLE
Update to ZIO 2.0.0-M6-2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 
-val zioVersion        = "2.0.0-M4"
+val zioVersion        = "2.0.0-M6-2"
 val rsVersion         = "1.0.3"
 val collCompatVersion = "2.5.0"
 

--- a/src/main/scala/zio/interop/reactivestreams/package.scala
+++ b/src/main/scala/zio/interop/reactivestreams/package.scala
@@ -21,7 +21,9 @@ package object reactivestreams {
       Adapters.streamToPublisher(stream)
   }
 
-  final implicit class sinkToSubscriber[R, InErr >: Throwable, E <: Throwable, A, L, Z](private val sink: ZSink[R, InErr, A, E, L, Z]) {
+  final implicit class sinkToSubscriber[R, InErr >: Throwable, E <: Throwable, A, L, Z](
+    private val sink: ZSink[R, InErr, A, E, L, Z]
+  ) {
 
     /** Create a `Subscriber` from a `Sink`. The returned IO will eventually return the result of running the subscribed
       * stream to the sink. Consumption is started as soon as the resource is used, even if the IO is never run.

--- a/src/main/scala/zio/interop/reactivestreams/package.scala
+++ b/src/main/scala/zio/interop/reactivestreams/package.scala
@@ -21,8 +21,7 @@ package object reactivestreams {
       Adapters.streamToPublisher(stream)
   }
 
-  final implicit class sinkToSubscriber[R, E <: Throwable, A, L, Z](private val sink: ZSink[R, E, A, L, Z])
-      extends AnyVal {
+  final implicit class sinkToSubscriber[R, InErr >: Throwable, E <: Throwable, A, L, Z](private val sink: ZSink[R, InErr, A, E, L, Z]) {
 
     /** Create a `Subscriber` from a `Sink`. The returned IO will eventually return the result of running the subscribed
       * stream to the sink. Consumption is started as soon as the resource is used, even if the IO is never run.
@@ -61,7 +60,7 @@ package object reactivestreams {
       */
     def toSink[E <: Throwable](implicit
       trace: ZTraceElement
-    ): ZManaged[Any, Nothing, (Promise[E, Nothing], ZSink[Any, Nothing, I, I, Unit])] =
+    ): ZManaged[Any, Nothing, (Promise[E, Nothing], ZSink[Any, E, I, E, I, Unit])] =
       Adapters.subscriberToSink(subscriber)
   }
 

--- a/src/test/scala/zio/interop/reactivestreams/PublisherToStreamSpec.scala
+++ b/src/test/scala/zio/interop/reactivestreams/PublisherToStreamSpec.scala
@@ -46,7 +46,7 @@ object PublisherToStreamSpec extends DefaultRunnableSpec {
           runtime    <- ZIO.runtime[Any]
           testRuntime = runtime
 //            .mapRuntimeConfig(_.copy(supervisor = supervisor))
-          exit        = testRuntime.unsafeRun(publisher.toStream().runDrain.exit)
+          exit = testRuntime.unsafeRun(publisher.toStream().runDrain.exit)
 //          stats      <- supervisor.value
         } yield assert(exit)(fails(anything)) /* &&
           assert(stats.failures)(equalTo(0L))*/

--- a/src/test/scala/zio/interop/reactivestreams/SinkToSubscriberSpec.scala
+++ b/src/test/scala/zio/interop/reactivestreams/SinkToSubscriberSpec.scala
@@ -20,7 +20,6 @@ import zio.stream.Sink
 import zio.stream.ZSink
 import zio.test.Assertion._
 import zio.test._
-import zio.test.environment.Live
 
 object SinkToSubscriberSpec extends DefaultRunnableSpec {
   override def spec =
@@ -29,7 +28,7 @@ object SinkToSubscriberSpec extends DefaultRunnableSpec {
         for {
           (publisher, subscribed, requested, canceled) <- makePublisherProbe
           fiber <- ZSink
-                     .fold[Int, Chunk[Int]](Chunk.empty)(_.size < 5)(_ :+ _)
+                     .fold[Throwable, Int, Chunk[Int]](Chunk.empty)(_.size < 5)(_ :+ _)
                      .map(_.toList)
                      .toSubscriber()
                      .use { case (subscriber, r) =>
@@ -52,7 +51,7 @@ object SinkToSubscriberSpec extends DefaultRunnableSpec {
         for {
           (publisher, subscribed, _, canceled) <- makePublisherProbe
           fiber <- Sink
-                     .foreachChunk[Any, Nothing, Int](_ => ZIO.yieldNow)
+                     .foreachChunk[Any, Throwable, Int](_ => ZIO.yieldNow)
                      .toSubscriber()
                      .use { case (subscriber, _) => UIO(publisher.subscribe(subscriber)) *> UIO.never }
                      .fork
@@ -71,7 +70,7 @@ object SinkToSubscriberSpec extends DefaultRunnableSpec {
         for {
           (publisher, subscribed, requested, canceled) <- makePublisherProbe
           fiber <- Sink
-                     .foreachChunk[Any, Nothing, Int](_ => ZIO.yieldNow)
+                     .foreachChunk[Any, Throwable, Int](_ => ZIO.yieldNow)
                      .toSubscriber()
                      .use { case (subscriber, _) =>
                        Task.attemptBlockingInterrupt(publisher.subscribe(subscriber)) *> UIO.never
@@ -138,7 +137,7 @@ object SinkToSubscriberSpec extends DefaultRunnableSpec {
 
   val managedVerification =
     for {
-      subscriber_    <- Sink.collectAll[Int].toSubscriber()
+      subscriber_    <- Sink.collectAll[Throwable, Int].toSubscriber()
       (subscriber, _) = subscriber_
       sbv <- ZManaged.acquireReleaseWith {
                val env = new TestEnvironment(1000, 500)


### PR DESCRIPTION
Work in progress, two problems:

- how can we express the test that used `Supervisor.runtimeStats`
- "cancels subscription on stream error" does not work