### PR TITLE
feat: rename toSink to toZIOSink and toStream to toZIOStream

### DIFF
--- a/src/main/scala/zio/interop/reactivestreams/package.scala
+++ b/src/main/scala/zio/interop/reactivestreams/package.scala
@@ -19,42 +19,41 @@ package object reactivestreams {
 
   final implicit class sinkToSubscriber[R, E <: Throwable, A, L, Z](private val sink: ZSink[R, E, A, L, Z]) {
 
-    /** Create a `Subscriber` from a `Sink`. The returned IO will eventually return the result of running the subscribed
-      * stream to the sink. Consumption is started as soon as the resource is used, even if the IO is never run.
-      * Interruption propagates from the `Zmanaged` to the stream, but not from the IO.
+    /** Create a `Subscriber` from a `Sink`. The returned Task will eventually return the result of running the
+      * subscribed stream to the sink. Consumption is started immediately, even if the Task is never run. Interruption
+      * propagates from this ZIO to the stream, but not from the Task.
       * @param qSize
-      *   The size used as internal buffer. A maximum of `qSize-1` `A`s will be buffered, so `qSize` must be > 1. If
-      *   possible, set to a power of 2 value for best performance.
+      *   The size used as internal buffer. If possible, set to a power of 2 value for best performance.
       */
     def toSubscriber(qSize: Int = 16)(implicit
       trace: ZTraceElement
-    ): ZIO[R with Scope, Throwable, (Subscriber[A], IO[Throwable, Z])] =
+    ): ZIO[R with Scope, Throwable, (Subscriber[A], Task[Z])] =
       Adapters.sinkToSubscriber(sink, qSize)
   }
 
   final implicit class publisherToStream[O](private val publisher: Publisher[O]) extends AnyVal {
 
-    /** @param qSize
-      *   The size used as internal buffer. A maximum of `qSize-1` `A`s will be buffered, so `qSize` must be > 1. If
-      *   possible, set to a power of 2 value for best performance.
+    /** Create a `Stream` from a `Publisher`.
+      * @param qSize
+      *   The size used as internal buffer. If possible, set to a power of 2 value for best performance.
       */
-    def toStream(qSize: Int = 16)(implicit trace: ZTraceElement): ZStream[Any, Throwable, O] =
+    def toZIOStream(qSize: Int = 16)(implicit trace: ZTraceElement): ZStream[Any, Throwable, O] =
       Adapters.publisherToStream(publisher, qSize)
   }
 
   final implicit class subscriberToSink[I](private val subscriber: Subscriber[I]) extends AnyVal {
 
-    /** Create a `Sink` from a `Subscriber`. Errors need to be transported via the returned Promise:
+    /** Create a `Sink` from a `Subscriber`. Errors need to be transported via the returned callback:
       *
       * ```
       * val subscriber: Subscriber[Int] = ???
       * val stream: Stream[Any, Throwable, Int] = ???
-      * subscriber.toSink.use { case (error, sink) =>
-      *   stream.run(sink).catchAll(e => error.fail(e))
+      * subscriber.toZIOSink.use { case (signalError, sink) =>
+      *   stream.run(sink).catchAll(signalError)
       * }
       * ```
       */
-    def toSink[E <: Throwable](implicit
+    def toZIOSink[E <: Throwable](implicit
       trace: ZTraceElement
     ): ZIO[Scope, Nothing, (E => UIO[Unit], ZSink[Any, Nothing, I, I, Unit])] =
       Adapters.subscriberToSink(subscriber)

--- a/src/main/scala/zio/interop/reactivestreams/package.scala
+++ b/src/main/scala/zio/interop/reactivestreams/package.scala
@@ -2,7 +2,7 @@ package zio.interop
 
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
-import zio.{ IO, Scope, UIO, ZIO, ZTraceElement }
+import zio.{ Scope, UIO, Task, ZIO, ZTraceElement }
 import zio.stream.ZSink
 import zio.stream.ZStream
 

--- a/src/test/scala/zio/interop/reactivestreams/SubscriberToSinkSpec.scala
+++ b/src/test/scala/zio/interop/reactivestreams/SubscriberToSinkSpec.scala
@@ -17,7 +17,7 @@ object SubscriberToSinkSpec extends ZIOSpecDefault {
         makeSubscriber.flatMap(probe =>
           ZIO.scoped[Any] {
             probe.underlying
-              .toSink[Throwable]
+              .toZIOSink[Throwable]
               .flatMap { case (_, sink) =>
                 for {
                   fiber      <- Stream.fromIterable(seq).run(sink).fork
@@ -34,7 +34,7 @@ object SubscriberToSinkSpec extends ZIOSpecDefault {
         makeSubscriber.flatMap(probe =>
           ZIO.scoped[Any] {
             probe.underlying
-              .toSink[Throwable]
+              .toZIOSink[Throwable]
               .flatMap { case (signalError, sink) =>
                 for {
                   fiber    <- (Stream.fromIterable(seq) ++ Stream.fail(e)).run(sink).catchAll(signalError).fork
@@ -51,7 +51,7 @@ object SubscriberToSinkSpec extends ZIOSpecDefault {
         makeSubscriber.flatMap(probe =>
           ZIO.scoped[Any] {
             probe.underlying
-              .toSink[Throwable]
+              .toZIOSink[Throwable]
               .flatMap { case (signalError, sink) =>
                 for {
                   _   <- ZStream.fail(e).run(sink).catchAll(signalError)
@@ -66,7 +66,7 @@ object SubscriberToSinkSpec extends ZIOSpecDefault {
           for {
             fiber <- ZIO.scoped {
                        probe.underlying
-                         .toSink[Throwable]
+                         .toZIOSink[Throwable]
                          .flatMap { case (signalError, sink) =>
                            ZStream.fail(e).run(sink).catchAll(signalError)
                          }
@@ -80,7 +80,7 @@ object SubscriberToSinkSpec extends ZIOSpecDefault {
         ZIO.scoped[Any] {
           for {
             probe              <- makeSubscriber
-            ses                <- probe.underlying.toSink
+            ses                <- probe.underlying.toZIOSink
             (signalError, sink) = ses
             _                  <- ZStream.fail(e).run(sink).catchAll(signalError)
             err                <- probe.expectError.exit


### PR DESCRIPTION
In order to ease use together with libraries, which offer their own conversions for reactive streams, we use more concrete names for our own implicits to avoid conflicts.

fixes Interop with Flux and Mono types #309